### PR TITLE
Properly implemented endpoint for GET /survey

### DIFF
--- a/backend/app/apis/admin.py
+++ b/backend/app/apis/admin.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 from app.apis.base_api import base_user_api
 from app.db import get_session
 from app.models.user import UserRole
@@ -17,5 +19,5 @@ auth_handler = get_auth_handler()
 )
 async def login(
     user_info: BaseAuthDetails, session: Session = Depends(get_session)
-) -> dict:
+) -> Dict:
     return base_user_api.user_login(user_info, UserRole.ADMIN, session)

--- a/backend/app/apis/service.py
+++ b/backend/app/apis/service.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 from app.apis.base_api import base_user_api
 from app.db import get_session
 from app.models.user import User, UserRole
@@ -17,7 +19,7 @@ auth_handler = get_auth_handler()
 )
 async def login(
     user_info: BaseAuthDetails, session: Session = Depends(get_session)
-) -> dict:
+) -> Dict:
     return base_user_api.user_login(user_info, UserRole.SERVICE, session)
 
 

--- a/backend/app/apis/survey.py
+++ b/backend/app/apis/survey.py
@@ -1,3 +1,5 @@
+from typing import Dict, List
+
 from app.db import get_session
 from app.services.survey import SurveyService
 from app.utils.auth import get_auth_handler
@@ -16,7 +18,7 @@ auth_handler = get_auth_handler()
 async def get_survey(
     session: Session = Depends(get_session),
     # user_id: str = Depends(auth_handler.auth_wrapper),
-) -> dict:
+) -> List[Dict]:
     return SurveyService(session).get_survey()
 
 
@@ -28,5 +30,5 @@ async def get_survey(
 async def submit_survey(
     session: Session = Depends(get_session),
     user_id: str = Depends(auth_handler.auth_wrapper),
-) -> dict:
+) -> Dict:
     return {"message": "not implemented yet"}

--- a/backend/app/services/survey.py
+++ b/backend/app/services/survey.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Dict, List
 
 from app.models.survey import Question
 from app.services.base import BaseService
@@ -8,12 +8,20 @@ from sqlmodel import select
 class SurveyService(BaseService):
     """Service for survey operations."""
 
-    def get_survey(self) -> List[Question]:
+    def get_survey(self) -> List[Dict]:
         """Returns all questions and answers in the survey."""
         statement = select(Question)
-        return self.session.exec(statement).all()
+        result = self.session.exec(statement).all()
+        survey = []
+        for question in result:
+            question_dict = question.model_dump()
+            question_dict["answers"] = [
+                answer.model_dump() for answer in question.answers
+            ]
+            survey.append(question_dict)
+        return survey
 
-    def read_survey_response(self, survey_response: dict) -> dict:
+    def read_survey_response(self, survey_response: Dict) -> Dict:
         """
         Receives a survey response from the frontend.
 


### PR DESCRIPTION
- Implemented an endpoint for GET /survey which returns a response with structure similar to this -> https://discord.com/channels/1205762136685682808/1205763856727543868/1219319045900337343
- Properly turns type annotation of `dict` into `Dict` (accessible via `from typing import Dict`)